### PR TITLE
Update default branch for live edit

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ searchgov_affiliate: datagov-resources
 github:
   organization: GSA
   repository: resources.data.gov
-  default_branch: master
+  default_branch: develop
 
 styles:
   - assets/uswds/css/styles.css


### PR DESCRIPTION
Updates the default GH branch, so that when you click "edit this page on GitHub", you'll be editing based on the develop branch.