### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,13 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-node-{{ checksum "package-lock.json" }}
-            - v1-node-
+            - v2-node-{{ checksum "package-lock.json" }}
+            - v2-node-
       - run:
           name: install node dependencies
           command: npm install
       - save_cache:
-          key: v1-node-{{ checksum "package-lock.json" }}
+          key: v2-node-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
 


### PR DESCRIPTION
Bump the cache fix missing sass binary. Looks like Node.js version was bumped in
the container.

```
Error: Missing binding
/home/circleci/project/node_modules/node-sass/vendor/linux-x64-72/binding.node
Node Sass could not find a binding for your current environment: Linux 64-bit
with Node.js 12.x
```