### PR TITLE
update tools.md - inclusion of tool to measure data literacy for agencies

### DIFF
--- a/pages/tools.md
+++ b/pages/tools.md
@@ -135,3 +135,5 @@ inside PDF files.
 [HMDA tools](https://github.com/cfpb/hmda-tools) import and analyze mortgage application data.
 
 [Data and Statistics about the U.S.](https://www.usa.gov/statistics).
+
+[Measuring data literacy against the DatabilitiesⓇ framework](http://www.datatothepeople.org) applies a robust, research-backed framework to assess organizational data literacy at an individual level.


### PR DESCRIPTION
Providing a resource ("Other Tools") to assist in the measurement of data literacy as per Action 4: Identify Opportunities to Increase Staff Data Skills.

I am the Founder of Data To The People and we own an internationally recognized data literacy competency framework, used by many governments and private sector organisations globally.  A free version of our tool is available via our site www.datatothepeople.org