### PR TITLE
Adding missing "/" so that new playbook loads

### DIFF
--- a/pages/playbooks.md
+++ b/pages/playbooks.md
@@ -6,7 +6,7 @@ primary_nav_section: Resources
 
 There are a number of playbook relevant to federal management and use, including the following:
 
-The [Assessing Data Skills Playbook]({{ site.baseurl }}assets/documents/assessing-data-skills-playbook.pdf) supports the Federal Data Strategy by helping agencies get started with assessing data skills. 
+The [Assessing Data Skills Playbook]({{ site.baseurl }}/assets/documents/assessing-data-skills-playbook.pdf) supports the Federal Data Strategy by helping agencies get started with assessing data skills. 
 
 The [Data Governance Playbook]({{ site.baseurl }}/assets/documents/fds-data-governance-playbook.pdf) supports the Federal Data Strategy by helping agencies get started with prioritizing data governance and assessing maturity. 
 


### PR DESCRIPTION
Link to Assessing Data Skills Playbook was broken due to missing forward slash. Adding this to fix. Preview [here](https://cg-f5a56614-c88e-470c-9f06-ff5fe2d4c98a.app.cloud.gov/preview/gsa/resources.data.gov/fix-data-skills-playbook/playbooks/)