### PR TITLE
fix glossary button text color

### DIFF
--- a/pages/_scss/components/_glossary.scss
+++ b/pages/_scss/components/_glossary.scss
@@ -11,6 +11,7 @@
   }
 
   button {
+    color: white;
     background: none;
     border: 0;
     @include u-text("left");


### PR DESCRIPTION
Fixes a regression in the glossary button text color.

# Before

![2020-06-18_08-54](https://user-images.githubusercontent.com/3013175/85043635-6d1f9b80-b141-11ea-860d-b5691ad8f2ad.png)

# After

![2020-06-18_08-55](https://user-images.githubusercontent.com/3013175/85043639-6db83200-b141-11ea-9d25-611d88b7057f.png)
