### PR TITLE
Add a redirect for /schemas/dcat-us/v1.1/

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "jekyll", "~> 3.8.5"
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
   gem "jekyll-toc", "~> 0.13"
+  gem 'jekyll-redirect-from'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-feed (0.13.0)
       jekyll (>= 3.7, < 5.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-sitemap (1.4.0)
@@ -85,6 +87,7 @@ DEPENDENCIES
   html-proofer (>= 3.13.0)
   jekyll (~> 3.8.5)
   jekyll-feed (~> 0.6)
+  jekyll-redirect-from
   jekyll-sitemap
   jekyll-toc (~> 0.13)
   tzinfo-data

--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,7 @@ plugins:
   - jekyll-feed
   - jekyll-sitemap
   - jekyll-toc
+  - jekyll-redirect-from
 source: pages
 
 keep_files:

--- a/pages/_resources/dcat-us.md
+++ b/pages/_resources/dcat-us.md
@@ -1,4 +1,5 @@
 ---
+redirect_from: /schemas/dcat-us/v1.1/
 resource_name: DCAT-US Schema v1.1 (Project Open Data Metadata Schema)
 slug: dcat-us
 description: How to use Project Open Data Metadata Schema guidelines to document


### PR DESCRIPTION
Bugfix: r.d.g's highest traffic page is 404ing: https://resources.data.gov/schemas/dcat-us/v1.1/

This PR adds a redirect to the resource in question using `jekyll-redirect-from`.

