### PR TITLE
Fix Github Link

### DIFF
--- a/pages/_includes/footer.html
+++ b/pages/_includes/footer.html
@@ -38,7 +38,7 @@
               The Federal Enterprise Data Resources content is maintained by the <a href="">Data.gov</a> Program Management Office in <a href="https://www.gsa.gov/tts">GSA TTS</a>, the <a href="https://www.archives.gov/ogis">Office of Government and Information Services (OGIS)</a>, and the <a href="https://www.whitehouse.gov/omb/">Office of Management and Budget (OMB)</a>. </p>
             <p>
               Help us improve this site
-              on <a href="https://github.com/{{ site.github.organization }}/{{ site.github.repository }}/edit/{{ site.github.default_branch }}/pages/{{ page.path }}">GitHub</a>.
+              on <a href="https://github.com/{{ site.github.organization }}/{{ site.github.repository }}/edit/main/pages/{{ page.path }}">GitHub</a>.
             </p>
           </div>
         </div>


### PR DESCRIPTION
The current link to access the Github on the home page (and other pages that use the footer partial) points to https://github.com/GSA/resources.data.gov/edit/develop/pages/index.md which doesn't exist. It should be https://github.com/GSA/resources.data.gov/edit/main/pages/index.md which requires replacing the {{ site.github.default_branch }} with main