### PR TITLE
Update edit footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ significant changes to the site that require partner review.
 - [Ruby 2.6](https://www.ruby-lang.org/)
 - [Bundler 1.17.x](https://bundler.io/) (we use an older version for Federalist
   compatibility)
+    - install via `gem install bundler -v 1.17.3`
+    - use version by `bundle _1.17.3_ ...`
 - [Node.js 10](https://nodejs.org/)
 
 

--- a/pages/_includes/footer.html
+++ b/pages/_includes/footer.html
@@ -37,8 +37,12 @@
             <p class="margin-top-0">
               The Federal Enterprise Data Resources content is maintained by the <a href="">Data.gov</a> Program Management Office in <a href="https://www.gsa.gov/tts">GSA TTS</a>, the <a href="https://www.archives.gov/ogis">Office of Government and Information Services (OGIS)</a>, and the <a href="https://www.whitehouse.gov/omb/">Office of Management and Budget (OMB)</a>. </p>
             <p>
-              Help us improve this site
-              on <a href="https://github.com/{{ site.github.organization }}/{{ site.github.repository }}/edit/{{ site.github.default_branch }}/pages/{{ page.path }}">GitHub</a>.
+              Help us improve this site on
+              {% if page.path contains 'glossary' %}
+                <a href="https://github.com/{{ site.github.organization }}/{{ site.github.repository }}/edit/{{ site.github.default_branch }}/pages/_data/glossary.json">GitHub</a>.
+              {% else %}
+                <a href="https://github.com/{{ site.github.organization }}/{{ site.github.repository }}/edit/{{ site.github.default_branch }}/pages/{{ page.path }}">GitHub</a>.
+              {% endif %}
             </p>
           </div>
         </div>


### PR DESCRIPTION
Update documentation on bundle.
Update footer to handle glossary dynamically.

Related to https://github.com/GSA/datagov-deploy/issues/3522

Can manually pull and build locally to double check: `npm run build` & `npm run qa`.

This results in 33 external links to review, instead of [the current 85](https://app.circleci.com/pipelines/github/GSA/resources.data.gov/1303/workflows/2d694e38-4c85-4ba6-a729-06d007e17ca3/jobs/1315).
![image](https://user-images.githubusercontent.com/26980513/140834686-d2dd8246-7642-4747-b7d2-761beff58d21.png)
