### PR TITLE
Enlarge a clickable area of the keyword buttons

### DIFF
--- a/pages/_layouts/home.html
+++ b/pages/_layouts/home.html
@@ -88,11 +88,10 @@ class: home
       <div class="display-flex flex-row flex-wrap">
         {% for tag in site.keywords %}
           <div class="mobile-lg:grid-col-6 tablet:grid-col-6 desktop:grid-col-4">
-            <div class="border-primary-vivid border-2px radius-lg padding-1 hover:bg-base-lightest hover:shadow-2 margin-05 display-flex flex-justify-center text-center">
-              <a href="{{ tag.url | relative_url }}" class="text-no-underline display-flex flex-align-center">
-                {{ tag.keyword_name }}
-              </a>
-            </div>
+            <a href="{{ tag.url | relative_url }}" class="border-primary-vivid border-2px radius-lg padding-1 hover:bg-base-lightest hover:shadow-2 margin-05 text-no-underline display-flex flex-justify-center">
+              
+              {{ tag.keyword_name }}
+            </a>
           </div>
         {% endfor %}
       </div>


### PR DESCRIPTION
Hello🙂 Is this repository accepting a PR from people outside? I'm neither a member of any organization nor a US citizen.

Currently, the clickable area of buttons is too narrow but the button is highlighted when hovering. This causes users to misunderstand the clickable area.

This PR fixes the issue about keyword buttons by enlarging the clickable area of the buttons.

## Screenshot

The color of the button changed even if the pointer is above the unclickable area.
<img width="509" alt="Screen Shot 2022-01-09 at 18 23 57" src="https://user-images.githubusercontent.com/1425259/148676840-70a91448-d0f0-4227-96b9-22165c2e80e1.png">

**before: Current clickable area**
<img width="646" alt="Screen Shot 2022-01-09 at 18 23 34" src="https://user-images.githubusercontent.com/1425259/148676807-ae5b60df-14d9-4855-8b69-dd4f059de701.png">

**after: New clickable area**
<img width="674" alt="Screen Shot 2022-01-09 at 18 23 48" src="https://user-images.githubusercontent.com/1425259/148676819-758588fb-65ca-479b-8bfb-6898ce901a5c.png">

