### PR TITLE
downgrade gulp for uswds-gulp; ignore major release of gulp in depend…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "gulp"
+        update-types: ["version-update:semver-major"]

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "cssnano": "^6.1.1",
     "fuse.js": "^7.0.0",
     "glossary-panel": "^1.0.0",
-    "gulp": "^5.0.0",
+    "gulp": "^4.0.2",
     "gulp-dart-sass": "^1.1.0",
     "gulp-postcss": "^9.1.0",
     "gulp-rename": "^2.0.0",


### PR DESCRIPTION
# Pull Request

Related to [#4756](https://github.com/GSA/data.gov/issues/4756)

## About

- downgrade gulp to `^4.0.2` in order to be [compatible with uswds-gulp](https://github.com/uswds/uswds-gulp#:~:text=del-,gulp%40%5E4.0.2,-gulp%2Dreplace). add major release ignore in dependabot config
- [no snyk issues with 4.0.2](https://snyk.io/advisor/npm-package/gulp). should we pin to this version?

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [x] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [x] Any new
      [Gemfile](https://github.com/GSA/resources.data.gov/blob/main/Gemfile)
      or
      [package.json](https://github.com/GSA/resources.data.gov/blob/main/package.json)
      updates to pull in?
