### PR TITLE
Swap GA script for GTM

### DIFF
--- a/pages/_includes/google-analytics.html
+++ b/pages/_includes/google-analytics.html
@@ -1,11 +1,7 @@
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-WP7FK9QXZD"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag() {
-    dataLayer.push(arguments);
-  }
-  gtag('js', new Date());
-
-  gtag('config', 'G-WP7FK9QXZD');
-</script>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-WZJC8CX7');</script>
+<!-- End Google Tag Manager -->


### PR DESCRIPTION
Approvers, please let me know if there are any other places we need to make an adjustment. This appears to be the only spot. This code should be injected into the <head>

This removes the Google Analytics <script> and instead inserts the Google Tag Manager container <script>, so we can manage GA from there

# Pull Request

Related to https://github.com/GSA/data.gov/issues/4709

