### PR TITLE
add federal-government-shutdown option

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,8 @@ github_username: GSA
 dap_agency: GSA
 searchgov_affiliate: datagov-resources
 
+federal_shutdown_mode: false
+
 github:
   organization: GSA
   repository: resources.data.gov

--- a/pages/_includes/federal-government-shutdown.html
+++ b/pages/_includes/federal-government-shutdown.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<title>Site Maintenance</title>
+<style>
+  body { text-align: center; padding-top: 100px; }
+  h1 { font-size: 50px; }
+  body { font: 20px Helvetica, sans-serif; color: #333; }
+  article { display: block; text-align: left; width: 650px; margin: 0 auto; }
+  a { color: #dc8100; text-decoration: none; }
+  a:hover { color: #333; text-decoration: none; }
+  img { display: block; width: 200px;}
+</style>
+
+
+<article>
+  <img src=https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/logo.svg alt="data.gov logo">
+  <h1>Site not available</h1>
+    <div>
+        <p>
+          The Federal Government is currently shut down. As a result, this site is unavailable until further notice. Please visit <a href="https://usa.gov">https://usa.gov</a> for more information.
+        </p>
+    </div>
+</article>

--- a/pages/_layouts/default.html
+++ b/pages/_layouts/default.html
@@ -1,6 +1,8 @@
 ---
 ---
-
+{% if site.federal_shutdown_mode %}
+  {% include federal-government-shutdown.html %}
+{% else %}
 <!DOCTYPE html>
 <!--[if lt IE 9]><html class="lt-ie9"><![endif]-->
 <!-- [if gt IE 8]><! -->
@@ -10,7 +12,6 @@
     <head>
         {% include google-analytics.html %} {% include meta.html %} {% include styles.html %}
     </head>
-
     <body class="{{ layout.class }} {{ page.class }}">
         <a class="usa-skipnav" href="#main-content">Skip to main content</a>
         {% include header.html %}
@@ -18,3 +19,4 @@
         {% include footer.html %} {% include identifier.html %} {% include glossary.html %} {% include scripts.html %}
     </body>
 </html>
+{% endif %}


### PR DESCRIPTION
# Pull Request

Added a `federal_shutdown_mode` config. In case federal government shutdown, assigning a true value to make all pages show the content of the federal-government-shutdown.html.

## About

<!-- any pertinent notes -->

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any new
      [Gemfile](https://github.com/GSA/resources.data.gov/blob/main/Gemfile)
      or
      [package.json](https://github.com/GSA/resources.data.gov/blob/main/package.json)
      updates to pull in?
