### PR TITLE
Add Content-Security-Policy meta tag

### DIFF
--- a/pages/_includes/meta.html
+++ b/pages/_includes/meta.html
@@ -4,11 +4,16 @@
   <!-- 'unsafe-eval' is required by the latest released 1.0.0 version of glossary.js -->
   <meta http-equiv="Content-Security-Policy" content="default-src 'none';
     font-src 'self' https://use.fontawesome.com;
-    script-src 'self' https://dap.digitalgov.gov 'unsafe-eval';
+    frame-src youtube.com www.youtube.com;
+    script-src 'self' https://dap.digitalgov.gov 'unsafe-eval'
+      'sha256-YA7FKxq4SsPjpF6nCIXnPuHXV/cbo/DEFJDHdjwDoAU=';
     connect-src 'self';
-    img-src 'self' data:;
+    img-src 'self' data:  https://strategy.data.gov;
     style-src-elem 'self' https://use.fontawesome.com;
-    style-src-attr 'self';
+    style-src-attr 'self' 'unsafe-hashes'
+      'sha256-6l+tpow5lGPV0MHWZlDv8nD7HrL77FGFldqQ7zc5gxY='
+      'sha256-i0JPB0qmRu5AViJTxOIzqXnfGoiWFw+oNAm4uJd7ZQk='
+      'sha256-Y9v1MZrln1N8aPBY5lmpxYKwFkcp/nyBMMEnn7WFjuw=';
     base-uri 'self';form-action 'self'">
 
 


### PR DESCRIPTION
# Pull Request

Related to GSA/Data.gov#4952

## About

This adds a Content-Security-Policy as a meta tag in our base template. 

One of the NPM packages we use `glossary-panel` has in it's latest released version a use of underscore's `template` function which calls `Function` which is not allowed without the `unsafe-eval` directive. Unfortunately, there is actually code in the `master` branch of https://github.com/18F/glossary to avoid that issue, but it hasn't been released to NPM. Rather than attempt to get a release made for that library, after reviewing the code, we accept that `Function` is being used safely and include the `unsafe-eval` directive.

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [X] The actual code changes.
