### PR TITLE
Relax CSP so DAP code can run

### DIFF
--- a/pages/_includes/meta.html
+++ b/pages/_includes/meta.html
@@ -5,9 +5,9 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'none';
     font-src 'self' https://use.fontawesome.com;
     frame-src youtube.com www.youtube.com;
-    script-src 'self' https://dap.digitalgov.gov 'unsafe-eval'
+    script-src 'self' https://dap.digitalgov.gov https://www.googletagmanager.com 'unsafe-eval'
       'sha256-YA7FKxq4SsPjpF6nCIXnPuHXV/cbo/DEFJDHdjwDoAU=';
-    connect-src 'self';
+    connect-src 'self' https://www.google-analytics.com;
     img-src 'self' data:  https://strategy.data.gov;
     style-src-elem 'self' https://use.fontawesome.com;
     style-src-attr 'self' 'unsafe-hashes'
@@ -15,7 +15,7 @@
       'sha256-i0JPB0qmRu5AViJTxOIzqXnfGoiWFw+oNAm4uJd7ZQk='
       'sha256-Y9v1MZrln1N8aPBY5lmpxYKwFkcp/nyBMMEnn7WFjuw=';
     form-action 'self' https://search.usa.gov;
-    base-uri 'self';form-action 'self'">
+    base-uri 'self'">
 
 
 <meta name="HandheldFriendly" content="True" />


### PR DESCRIPTION
## About

We observed that DAP wasn't recording visits on resources.data.gov. It needed two additional CSP directives to run completely.

## PR TASKS

- [X] The actual code changes.
- [X] Tests written and passed.
- [X] Any changes to docs?
- [X] Any new
      [Gemfile](https://github.com/GSA/resources.data.gov/blob/main/Gemfile)
      or
      [package.json](https://github.com/GSA/resources.data.gov/blob/main/package.json)
      updates to pull in?