### PR TITLE
Add explicit workflow token permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build & Test
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Static Site

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 15 * * 1'
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   qa:
     uses: gsa/data.gov/.github/workflows/static-site-qa-template.yml@main


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to:
  - `.github/workflows/build.yml`
  - `.github/workflows/qa.yml`
- Use least-privilege scopes (`contents: read`) and preserve issue-creation capability in QA (`issues: write`).

## Why
These workflows currently rely on implicit token defaults. Explicit scopes make access requirements clear and reduce unnecessary token privileges.