### PR TITLE
Correct date for OMB M-13-13 supersession

### DIFF
--- a/pages/_summaries/m-13-13.md
+++ b/pages/_summaries/m-13-13.md
@@ -9,7 +9,7 @@ resource_name: "SUPERSEDED: OMB M-13-13: Open Data Policy – Managing Informati
 description: "Office of Management and Budget memo that established a framework to help institutionalize
   the principles of effective information management at each stage of the information's life cycle to
   promote interoperability and openness. This guidance was rescinded and replaced by OMB M-25-05 on
-  January 13, 2025. Dated May 9, 2013."
+  January 15, 2025. Dated May 9, 2013."
 source: Office of Management and Budget
 category: Guidance
 tags:


### PR DESCRIPTION
Updated the date for the superseding memo from January 13, 2025 to January 15, 2025.

# Pull Request

Related to [LINK TO ISSUE]

## About

<!-- any pertinent notes -->

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any new
      [Gemfile](https://github.com/GSA/resources.data.gov/blob/main/Gemfile)
      or
      [package.json](https://github.com/GSA/resources.data.gov/blob/main/package.json)
      updates to pull in?
