### PR TITLE
rename npm package to avoid Snyk collision

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "resources.data.gov",
+    "name": "@gsa/resources-data-gov",
     "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "resources.data.gov",
+            "name": "@gsa/resources-data-gov",
             "version": "1.0.0",
             "license": "CC0-1.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "resources.data.gov",
+    "name": "@gsa/resources-data-gov",
     "version": "1.0.0",
     "description": "",
     "main": "index.js",


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/6066#issuecomment-4720912450

## About

Snyk flags the public npm package named `resources.data.gov` as malicious. This repository used the same string as its private root package name, which caused Snyk to associate the local project metadata with that advisory.

 Rename the private package metadata to `@gsa/resources-data-gov` in package.json and package-lock.json so scans identify this repo separately from the removed npm package.