### PR TITLE
ignore babel major version bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
     ignore:
       - dependency-name: "gulp"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "@babel/core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@babel/plugin-transform-runtime"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@babel/preset-env"
+        update-types: ["version-update:semver-major"]
     groups:
       # Group all npm updates together
       npm-packages:


### PR DESCRIPTION
bot keep pushing babel 8. it is not supported yet. we need to tell bot to stop.