### PR TITLE
remove vulnerable sourcemaps, update postcss

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,6 @@ const { src, pipe, dest, series, parallel, watch } = require('gulp');
 const uswds = require("@uswds/compile");
 
 var browserify = require('browserify');
-var sourcemaps = require('gulp-sourcemaps');
 var uglify = require('gulp-uglify')
 var gulpif = require('gulp-if');
 var source = require('vinyl-source-stream');
@@ -28,8 +27,6 @@ function jsTask() {
         .pipe(source(paths.js.dest))
         .pipe(buffer())
         .pipe(gulpif(isProd, uglify()))
-        .pipe(gulpif(!isProd, sourcemaps.init({ loadMaps: true })))
-        .pipe(gulpif(!isProd, sourcemaps.write('.')))
         .pipe(dest("_site"));
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
                 "browserify": "^17.0.1",
                 "gulp": "^5.0.1",
                 "gulp-if": "^3.0.0",
-                "gulp-sourcemaps": "^3.0.0",
                 "gulp-terser-js": "^5.2.2",
                 "gulp-uglify": "^3.0.2",
                 "vinyl-buffer": "^1.0.1",
@@ -1624,96 +1623,6 @@
             "integrity": "sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==",
             "license": "MIT"
         },
-        "node_modules/@gulp-sourcemaps/identity-map": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-2.0.1.tgz",
-            "integrity": "sha512-Tb+nSISZku+eQ4X1lAkevcQa+jknn/OVUgZ3XCxEKIsLsqYuPoJwJOPQeaOk75X3WPftb29GWY1eqE7GLsXb1Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^6.4.1",
-                "normalize-path": "^3.0.0",
-                "postcss": "^7.0.16",
-                "source-map": "^0.6.0",
-                "through2": "^3.0.1"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/@gulp-sourcemaps/identity-map/node_modules/picocolors": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-            "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/@gulp-sourcemaps/identity-map/node_modules/postcss": {
-            "version": "7.0.39",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-            "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "picocolors": "^0.2.1",
-                "source-map": "^0.6.1"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/postcss/"
-            }
-        },
-        "node_modules/@gulp-sourcemaps/identity-map/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@gulp-sourcemaps/identity-map/node_modules/through2": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-            "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.4",
-                "readable-stream": "2 || 3"
-            }
-        },
-        "node_modules/@gulp-sourcemaps/map-sources": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
-            "integrity": "sha512-o/EatdaGt8+x2qpb0vFLC/2Gug/xYPRXb6a+ET1wGYKozKN3krDWC/zZFZAtrzxJHuDL12mwdfEFKcKMNvc55A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "normalize-path": "^2.0.1",
-                "through2": "^2.0.3"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            }
-        },
-        "node_modules/@gulp-sourcemaps/map-sources/node_modules/normalize-path": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-            "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "remove-trailing-separator": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@gulpjs/messages": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@gulpjs/messages/-/messages-1.1.0.tgz",
@@ -2164,35 +2073,6 @@
                 "sass-embedded": "1.98.0"
             }
         },
-        "node_modules/@uswds/compile/node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.11",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
         "node_modules/@uswds/uswds": {
             "version": "3.13.0",
             "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.13.0.tgz",
@@ -2221,19 +2101,6 @@
                 "preact": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/acorn": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-            "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/acorn-node": {
@@ -2481,19 +2348,6 @@
             },
             "engines": {
                 "node": ">= 10.13.0"
-            }
-        },
-        "node_modules/atob": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-            "dev": true,
-            "license": "(MIT OR Apache-2.0)",
-            "bin": {
-                "atob": "bin/atob.js"
-            },
-            "engines": {
-                "node": ">= 4.5.0"
             }
         },
         "node_modules/autoprefixer": {
@@ -3611,18 +3465,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/css": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
-            "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.4",
-                "source-map": "^0.6.1",
-                "source-map-resolve": "^0.6.0"
-            }
-        },
         "node_modules/css-select": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -3663,16 +3505,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/fb55"
-            }
-        },
-        "node_modules/css/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/cssesc": {
@@ -3775,20 +3607,6 @@
                 "npm": ">=7.0.0"
             }
         },
-        "node_modules/d": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
-            "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "es5-ext": "^0.10.64",
-                "type": "^2.7.2"
-            },
-            "engines": {
-                "node": ">=0.12"
-            }
-        },
         "node_modules/dash-ast": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
@@ -3812,38 +3630,6 @@
                 "supports-color": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/debug-fabulous": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-1.1.0.tgz",
-            "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "3.X",
-                "memoizee": "0.4.X",
-                "object-assign": "4.X"
-            }
-        },
-        "node_modules/debug-fabulous/node_modules/debug": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.1"
-            }
-        },
-        "node_modules/decode-uri-component": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-            "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10"
             }
         },
         "node_modules/define-data-property": {
@@ -3937,16 +3723,6 @@
             "optional": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/detect-newline": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-            "integrity": "sha512-CwffZFvlJffUg9zZA0uqrjQayUTC8ob94pnr5sFwaVv3IOmkfUHcWH+jXaQK3askE51Cqe8/9Ql/0uXNwqZ8Zg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/detective": {
@@ -4233,62 +4009,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/es5-ext": {
-            "version": "0.10.64",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
-            "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "ISC",
-            "dependencies": {
-                "es6-iterator": "^2.0.3",
-                "es6-symbol": "^3.1.3",
-                "esniff": "^2.0.1",
-                "next-tick": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/es6-iterator": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-            "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "d": "1",
-                "es5-ext": "^0.10.35",
-                "es6-symbol": "^3.1.1"
-            }
-        },
-        "node_modules/es6-symbol": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
-            "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "d": "^1.0.2",
-                "ext": "^1.7.0"
-            },
-            "engines": {
-                "node": ">=0.12"
-            }
-        },
-        "node_modules/es6-weak-map": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "d": "1",
-                "es5-ext": "^0.10.46",
-                "es6-iterator": "^2.0.3",
-                "es6-symbol": "^3.1.1"
-            }
-        },
         "node_modules/escalade": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -4308,22 +4028,6 @@
                 "node": ">=0.8.0"
             }
         },
-        "node_modules/esniff": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
-            "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "d": "^1.0.1",
-                "es5-ext": "^0.10.62",
-                "event-emitter": "^0.3.5",
-                "type": "^2.7.2"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4332,17 +4036,6 @@
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/event-emitter": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-            "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "d": "1",
-                "es5-ext": "~0.10.14"
             }
         },
         "node_modules/events": {
@@ -4387,16 +4080,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/ext": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-            "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "type": "^2.7.2"
             }
         },
         "node_modules/extend": {
@@ -5110,46 +4793,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/gulp-sourcemaps": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-3.0.0.tgz",
-            "integrity": "sha512-RqvUckJkuYqy4VaIH60RMal4ZtG0IbQ6PXMNkNsshEGJ9cldUPRb/YCgboYae+CLAs1HQNb4ADTKCx65HInquQ==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@gulp-sourcemaps/identity-map": "^2.0.1",
-                "@gulp-sourcemaps/map-sources": "^1.0.0",
-                "acorn": "^6.4.1",
-                "convert-source-map": "^1.0.0",
-                "css": "^3.0.0",
-                "debug-fabulous": "^1.0.0",
-                "detect-newline": "^2.0.0",
-                "graceful-fs": "^4.0.0",
-                "source-map": "^0.6.0",
-                "strip-bom-string": "^1.0.0",
-                "through2": "^2.0.0"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/gulp-sourcemaps/node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/gulp-sourcemaps/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/gulp-svgstore": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/gulp-svgstore/-/gulp-svgstore-9.0.0.tgz",
@@ -5771,13 +5414,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-promise": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-            "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/is-regex": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6138,16 +5774,6 @@
                 "yallist": "^3.0.2"
             }
         },
-        "node_modules/lru-queue": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-            "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es5-ext": "~0.10.2"
-            }
-        },
         "node_modules/make-error": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -6208,26 +5834,6 @@
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
             "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
             "license": "CC0-1.0"
-        },
-        "node_modules/memoizee": {
-            "version": "0.4.17",
-            "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
-            "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "d": "^1.0.2",
-                "es5-ext": "^0.10.64",
-                "es6-weak-map": "^2.0.3",
-                "event-emitter": "^0.3.5",
-                "is-promise": "^2.2.2",
-                "lru-queue": "^0.1.0",
-                "next-tick": "^1.1.0",
-                "timers-ext": "^0.1.7"
-            },
-            "engines": {
-                "node": ">=0.12"
-            }
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
@@ -6379,13 +5985,6 @@
             "engines": {
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
-        },
-        "node_modules/next-tick": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-            "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/node-addon-api": {
             "version": "7.1.1",
@@ -8512,18 +8111,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/source-map-resolve": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-            "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-            "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "atob": "^2.1.2",
-                "decode-uri-component": "^0.2.0"
-            }
-        },
         "node_modules/source-map-support": {
             "version": "0.5.21",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -8703,16 +8290,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/strip-bom-string": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-            "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/stylehacks": {
@@ -8989,20 +8566,6 @@
                 "node": ">=0.6.0"
             }
         },
-        "node_modules/timers-ext": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
-            "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "es5-ext": "^0.10.64",
-                "next-tick": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.12"
-            }
-        },
         "node_modules/to-buffer": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
@@ -9072,13 +8635,6 @@
             "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/type": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
-            "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/typed-array-buffer": {
             "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     },
     "overrides": {
         "@uswds/compile": {
-            "postcss": "8.5.16"
+            "postcss": "^8.5.16"
         },
         "shell-quote": "1.9.0",
         "node-notifier": {

--- a/package.json
+++ b/package.json
@@ -47,13 +47,15 @@
         "browserify": "^17.0.1",
         "gulp": "^5.0.1",
         "gulp-if": "^3.0.0",
-        "gulp-sourcemaps": "^3.0.0",
         "gulp-terser-js": "^5.2.2",
         "gulp-uglify": "^3.0.2",
         "vinyl-buffer": "^1.0.1",
         "vinyl-source-stream": "^2.0.0"
     },
     "overrides": {
+        "@uswds/compile": {
+            "postcss": "8.5.16"
+        },
         "shell-quote": "1.9.0",
         "node-notifier": {
             "uuid": "11.1.1"


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/resources.data.gov/security/dependabot/104
- https://github.com/GSA/resources.data.gov/security/dependabot/34

## About

- add an override for @uswds/compile so its nested postcss@8.5.8 resolves to ^8.5.16.
- remove vulnerable sourcemaps because its latest release still depends on old  postcss. It was used only to help developers debug JavaScript locally, removing it has no impact on prod. 

